### PR TITLE
Open Water page: video hero + Recent Guest Catches sections

### DIFF
--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="indexifembedded">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow+Condensed:wght@600;700;800&family=Barlow:wght@300;400&display=swap">
+<style>
+*,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
+html,body{width:100%;height:auto;overflow-x:hidden;overflow-y:visible;background:#08080a}
+:root{
+  --red:#c1272d;
+  --red-glow:rgba(193,39,45,0.55);
+  --bg:#08080a;
+  --white:#fff;
+  --white-60:rgba(255,255,255,0.6);
+  --white-14:rgba(255,255,255,0.14);
+  --bone:#c8c5bd;
+  --pearl:#e8e6e0;
+}
+.hero{position:relative;width:100%;min-height:100svh;overflow:hidden;display:flex;background:var(--bg);font-family:'Barlow',sans-serif}
+.hero__video{position:absolute;inset:0;z-index:1;opacity:0;transition:opacity 0.6s cubic-bezier(0.4,0,0.2,1);pointer-events:none;transform:translateZ(0);backface-visibility:hidden;background:var(--bg)}
+.hero__video video{width:100%;height:100%;object-fit:cover;object-position:center 25%;transform:translateZ(0);display:block}
+.hero__video.is-ready{opacity:1}
+.hero__veil{position:absolute;inset:0;z-index:3;background:linear-gradient(105deg,rgba(8,8,10,0.93) 0%,rgba(8,8,10,0.78) 35%,rgba(8,8,10,0.35) 62%,rgba(8,8,10,0.08) 100%)}
+.hero__vignette{position:absolute;bottom:0;left:0;right:0;height:220px;z-index:4;background:linear-gradient(to bottom,transparent,rgba(8,8,10,0.9));pointer-events:none}
+.bracket{position:absolute;width:48px;height:48px;z-index:8;pointer-events:none;opacity:0;animation:bIn 0.5s cubic-bezier(0.4,0,0.2,1) forwards}
+.bracket--tl{top:24px;left:24px;border-top:1.5px solid var(--red);border-left:1.5px solid var(--red);animation-delay:0.3s}
+.bracket--tr{top:24px;right:24px;border-top:1.5px solid var(--red);border-right:1.5px solid var(--red);animation-delay:0.42s}
+.bracket--bl{bottom:24px;left:24px;border-bottom:1.5px solid var(--red);border-left:1.5px solid var(--red);animation-delay:0.54s}
+.bracket--br{bottom:24px;right:24px;border-bottom:1.5px solid var(--red);border-right:1.5px solid var(--red);animation-delay:0.66s}
+@keyframes bIn{to{opacity:1}}
+.hero__inner{position:relative;z-index:10;width:100%;max-width:680px;padding:clamp(80px,10vh,120px) clamp(32px,5vw,72px) clamp(60px,8vh,100px);display:flex;flex-direction:column;align-items:flex-start;justify-content:center}
+.hero__eyebrow{display:inline-flex;align-items:center;gap:12px;font-family:'Barlow Condensed',sans-serif;font-size:10px;font-weight:600;letter-spacing:0.42em;text-transform:uppercase;color:var(--red);margin-bottom:20px;opacity:0;animation:fU 0.6s ease forwards;animation-delay:0.18s}
+.hero__eyebrow::before{content:'';display:block;width:22px;height:1px;background:var(--red)}
+.hero__headline{font-family:'Bebas Neue',sans-serif;font-size:clamp(58px,7.5vw,108px);line-height:0.9;letter-spacing:0.01em;color:var(--white);opacity:0;animation:fU 0.7s cubic-bezier(0.2,0,0,1) forwards;animation-delay:0.3s}
+.hero__headline .accent{color:var(--red);display:block}
+.hero__headline .ghost{color:transparent;-webkit-text-stroke:1.5px rgba(255,255,255,0.22);display:block}
+.hero__divider{display:flex;align-items:center;gap:14px;margin:22px 0 26px;opacity:0;animation:fU 0.5s ease forwards;animation-delay:0.45s}
+.hero__divider-line{height:1px;width:60px;background:linear-gradient(90deg,var(--red),transparent)}
+.hero__divider-dot{width:5px;height:5px;background:var(--red);transform:rotate(45deg);box-shadow:0 0 8px 2px var(--red-glow)}
+/*
+  Hero body keeps --white-60 (rgba(255,255,255,0.6)) intentionally:
+  this section sits over a video/dark gradient where the body-text
+  bone token would visually muddy the contrast. Bone/pearl tokens are
+  still declared in :root so the rest of the page can pull them.
+*/
+.hero__body{font-weight:300;font-size:clamp(14px,1.5vw,17px);line-height:1.75;color:var(--white-60);max-width:480px;margin-bottom:40px;letter-spacing:0.025em;opacity:0;animation:fU 0.6s ease forwards;animation-delay:0.55s}
+.hero__body strong{color:var(--white);font-weight:500;}
+.hero__cta{display:flex;gap:14px;flex-wrap:wrap;margin-bottom:52px;opacity:0;animation:fU 0.6s ease forwards;animation-delay:0.7s}
+.btn{font-family:'Barlow Condensed',sans-serif;font-size:12.65px;font-weight:700;letter-spacing:0.28em;text-transform:uppercase;text-decoration:none;padding:16px 38px;display:inline-flex;align-items:center;gap:10px;cursor:pointer;border:none;position:relative;overflow:hidden;transition:background 0.25s ease,box-shadow 0.25s ease,border-color 0.25s ease;white-space:nowrap}
+.btn svg{width:12px;height:12px;fill:none;stroke:currentColor;stroke-width:2.5;transition:transform 0.25s ease}
+.btn:hover svg{transform:translateX(4px)}
+.btn--primary{background:var(--red);color:var(--white);clip-path:polygon(10px 0%,100% 0%,calc(100% - 10px) 100%,0% 100%)}
+.btn--primary:hover{box-shadow:0 0 32px var(--red-glow),0 8px 24px rgba(0,0,0,0.4)}
+.btn--ghost{background:transparent;color:var(--white);border:1px solid rgba(255,255,255,0.28);clip-path:polygon(10px 0%,100% 0%,calc(100% - 10px) 100%,0% 100%)}
+.btn--ghost:hover{border-color:rgba(255,255,255,0.65);background:rgba(255,255,255,0.07)}
+.stat-strip{display:flex;align-items:center;opacity:0;animation:fU 0.6s ease forwards;animation-delay:0.85s}
+.stat{display:flex;flex-direction:column;padding:0 26px;position:relative}
+.stat:first-child{padding-left:0}
+.stat+.stat::before{content:'';position:absolute;left:0;top:10%;bottom:10%;width:1px;background:var(--white-14)}
+.stat__num{font-family:'Barlow Condensed',sans-serif;font-weight:800;font-size:clamp(28px,3.2vw,42px);line-height:1;color:var(--white)}
+.stat__num em{color:var(--red);font-style:normal}
+.stat__lbl{font-size:9px;font-weight:500;letter-spacing:0.2em;text-transform:uppercase;color:rgba(255,255,255,0.35);margin-top:5px}
+@keyframes fU{from{opacity:0;transform:translateY(16px)}to{opacity:1;transform:translateY(0)}}
+@media (prefers-reduced-motion:reduce){
+  *,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}
+}
+@media(max-width:768px){
+  .hero{min-height:auto;padding-bottom:24px}
+  .hero__video video{object-position:50% 30%}
+  .hero__veil{background:linear-gradient(180deg,rgba(8,8,10,0.55) 0%,rgba(8,8,10,0.35) 30%,rgba(8,8,10,0.7) 55%,rgba(8,8,10,0.95) 78%,rgba(8,8,10,0.98) 100%)}
+  .hero__inner{max-width:100%;padding:18svh 24px 36px;justify-content:flex-start;align-items:center;text-align:center;min-height:auto}
+  .hero__eyebrow{display:none}
+  .hero__body{max-width:100%}
+  .hero__cta{justify-content:center;gap:12px;margin-bottom:36px}
+  .btn{font-size:11.5px;padding:14px 28px}
+  .stat-strip{justify-content:center}
+  .stat{padding:0 18px}
+  .bracket{width:32px;height:32px}
+  .bracket--tl,.bracket--tr{top:14px}
+  .bracket--bl,.bracket--br{bottom:14px}
+  .bracket--tl,.bracket--bl{left:14px}
+  .bracket--tr,.bracket--br{right:14px}
+}
+@media(max-width:400px){
+  .hero__headline{font-size:clamp(42px,11vw,54px)}
+  .stat-strip{flex-wrap:wrap;gap:8px}
+  .stat{padding:0 14px}
+}
+</style>
+</head>
+<body>
+<section class="hero" aria-label="Baxstar Fishing — Detroit Lakes Minnesota Open Water Guided Fishing">
+  <div class="hero__video" id="heroVideo" aria-hidden="true">
+    <!-- ───────────────────────────────────────────────────────────────
+         POSTER FALLBACK (optional): the still image shown while the video
+         loads (and if it fails). Replace the placeholder below or remove
+         the poster attribute entirely. -->
+    <video autoplay muted loop playsinline preload="auto" width="1920" height="1080"
+           poster="PASTE_POSTER_IMAGE_URL_HERE.jpg"></video>
+  </div>
+  <div class="hero__veil" aria-hidden="true"></div>
+  <div class="hero__vignette" aria-hidden="true"></div>
+  <div class="bracket bracket--tl" aria-hidden="true"></div>
+  <div class="bracket bracket--tr" aria-hidden="true"></div>
+  <div class="bracket bracket--bl" aria-hidden="true"></div>
+  <div class="bracket bracket--br" aria-hidden="true"></div>
+  <div class="hero__inner">
+    <p class="hero__eyebrow">Detroit Lakes, Minnesota · Open Water Guided Fishing</p>
+    <h1 class="hero__headline">
+      <span class="ghost">Open Water.</span>
+      <span class="accent">Big Fish.</span>
+      Endless Days.
+    </h1>
+    <div class="hero__divider" aria-hidden="true">
+      <div class="hero__divider-line"></div>
+      <div class="hero__divider-dot"></div>
+    </div>
+    <p class="hero__body">From ice-out in spring through the last cast of fall, Detroit Lakes' open water season puts you on walleye, bass, pike, and panfish. Every trip is <strong>100% private</strong> aboard a fully rigged boat with a <strong>5× Master Angler</strong> who's spent 30+ years reading these waters.</p>
+    <nav class="hero__cta" aria-label="Primary booking actions">
+      <a href="https://fareharbor.com/embeds/book/baxstarfishing/items/309836/calendar/2026/04/?full-items=yes&back=https://www.baxstarfishing.com/" class="btn btn--primary" aria-label="Book a guided open water fishing trip">
+        Book Your Trip
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M5 12h14M12 5l7 7-7 7"/></svg>
+      </a>
+      <a href="https://www.baxstarfishing.com/detroitlakesfishingreport" target="_top" class="btn btn--ghost" aria-label="Read the Detroit Lakes fishing report by Brady Baxter">Read Fishing Report</a>
+    </nav>
+    <div class="stat-strip" role="list" aria-label="Baxstar Fishing credentials">
+      <div class="stat" role="listitem"><div class="stat__num">30<em>+</em></div><div class="stat__lbl">Years Fishing</div></div>
+      <div class="stat" role="listitem"><div class="stat__num">5<em>×</em></div><div class="stat__lbl">Master Angler</div></div>
+      <div class="stat" role="listitem"><div class="stat__num">4.9<em>★</em></div><div class="stat__lbl">Google Rating</div></div>
+      <div class="stat" role="listitem"><div class="stat__num">100<em>%</em></div><div class="stat__lbl">Private Trips</div></div>
+    </div>
+  </div>
+</section>
+<script>
+(function(){
+  // ═══════════════════════════════════════════════════════════════
+  // HERO VIDEO SOURCE — ▼▼▼ REPLACE THE PLACEHOLDER BELOW ▼▼▼
+  // ───────────────────────────────────────────────────────────────
+  // Paste your open water hero video URL between the quotes. A Wix-
+  // hosted .mp4 looks like:
+  //   https://video.wixstatic.com/video/<id>/1080p/mp4/file.mp4
+  //
+  // OPTIONAL: if you have a smaller/lighter file for phones, paste it
+  // into MOBILE_SRC too. If you only have one video, leave MOBILE_SRC
+  // equal to HERO_VIDEO_URL and it will be used everywhere.
+  // ═══════════════════════════════════════════════════════════════
+  var HERO_VIDEO_URL = 'PASTE_YOUR_VIDEO_URL_HERE.mp4';
+  var MOBILE_SRC     = HERO_VIDEO_URL;
+  // ───────────────────────────────────────────────────────────────
+
+  var w = document.getElementById('heroVideo');
+  var v = w && w.querySelector('video');
+  if (!v) return;
+
+  // Until a real URL is pasted, leave the poster image showing and skip
+  // trying to load the placeholder (avoids a broken-video flash).
+  if (!HERO_VIDEO_URL || /PASTE_YOUR_VIDEO_URL_HERE/.test(HERO_VIDEO_URL)) {
+    w.classList.add('is-ready');
+    return;
+  }
+
+  function addSrc(u){
+    var n = document.createElement('source');
+    n.src = u;
+    n.type = 'video/mp4';
+    v.appendChild(n);
+  }
+
+  // Bandwidth-aware source selection
+  var conn     = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+  var saveData = conn && conn.saveData;
+  var slowNet  = conn && /2g|slow-2g/i.test(conn.effectiveType || '');
+  var isMobile = window.matchMedia('(max-width:768px)').matches;
+  var useMobileSrc = (saveData || slowNet || isMobile) && MOBILE_SRC && MOBILE_SRC !== HERO_VIDEO_URL;
+
+  // One-shot fallback: swap to the mobile source if the primary fails,
+  // so the hero never goes dark.
+  v.addEventListener('error', function r(){
+    while (v.firstChild) v.removeChild(v.firstChild);
+    addSrc(MOBILE_SRC);
+    v.removeEventListener('error', r);
+    v.load();
+    v.play().catch(function(){});
+  }, { once: true, passive: true });
+
+  addSrc(useMobileSrc ? MOBILE_SRC : HERO_VIDEO_URL);
+
+  // Reveal as soon as enough data exists to start playback
+  v.addEventListener('canplay',function r(){
+    v.removeEventListener('canplay',r);
+    requestAnimationFrame(function(){w.classList.add('is-ready')});
+  },{passive:true});
+
+  // Trigger immediately — video is now critical hero content
+  v.load();
+  v.play().catch(function(){});
+
+  // Pause when hero is offscreen (parent posts visibility messages)
+  window.addEventListener('message',function(e){
+    if(!e.data||e.data.type!=='baxstar_visibility')return;
+    try{e.data.hidden?v.pause():v.play().catch(function(){})}catch(err){}
+  },{passive:true});
+})();
+</script>
+
+<!-- IFRAME HEIGHT REPORTER — multi-signal (Wix Custom Embed auto-resize) -->
+<script>
+(function(){
+  if (window.parent === window) return;
+  var lastH = 0;
+  function report(){
+    var h = Math.max(
+      document.documentElement.scrollHeight,
+      document.body ? document.body.scrollHeight : 0,
+      document.documentElement.offsetHeight,
+      document.body ? document.body.offsetHeight : 0
+    );
+    if (h && Math.abs(h - lastH) >= 2) {
+      lastH = h;
+      try { window.parent.postMessage({ type: 'setHeight', height: h }, '*'); } catch(e){}
+      try { window.parent.postMessage({ type: 'embed-size', height: h }, '*'); } catch(e){}
+      try { window.parent.postMessage('height:' + h, '*'); } catch(e){}
+    }
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', report);
+  else report();
+  window.addEventListener('load', report);
+  window.addEventListener('resize', report);
+  if (document.fonts && document.fonts.ready) document.fonts.ready.then(report);
+  if (window.ResizeObserver) {
+    try { var ro = new ResizeObserver(report); ro.observe(document.documentElement); if (document.body) ro.observe(document.body); } catch(e){}
+  }
+  if (window.MutationObserver && document.body) {
+    try { new MutationObserver(report).observe(document.body, { subtree:true, childList:true, attributes:true, attributeFilter:['class','style'] }); } catch(e){}
+  }
+  var ticks = 0;
+  var early = setInterval(function(){
+    report(); ticks++;
+    if (ticks >= 30) { clearInterval(early); setInterval(report, 1500); }
+  }, 200);
+})();
+</script>
+<script>
+(function(){
+  'use strict';
+  document.addEventListener('click', function(e){
+    var a = e.target.closest && e.target.closest('a[href*="fareharbor.com/embeds/book"]');
+    if (!a) return;
+    var href = a.getAttribute('href') || '';
+    var item = (href.match(/\/items\/(\d+)/) || [])[1];
+    if (!item) return;
+    var flow = (href.match(/[?&]flow=(\d+)/) || [])[1];
+    e.preventDefault();
+    var open = { type:'baxstar_open_fareharbor', shortname:'baxstarfishing', item:item };
+    if (flow) open.flow = flow;
+    try { window.parent.postMessage(open, '*'); } catch(err){}
+    try { window.parent.postMessage({ type:'baxstar_event', event:'book_now_click',
+          location: a.getAttribute('data-track') || 'cta' }, '*'); } catch(err){}
+  }, false);
+})();
+</script>
+</body>
+</html>

--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -27,7 +27,7 @@
   "name": "Open Water Guided Fishing on Detroit Lakes — Baxstar Fishing",
   "description": "Aerial footage of a private open water guided fishing trip on Detroit Lakes, Minnesota with Baxstar Fishing — walleye, bass, pike, and panfish from ice-out through fall.",
   "thumbnailUrl": ["https://static.wixstatic.com/media/a30e59_f99144dec60b4cf4aa7bcc4f4762d2ff~mv2.webp"],
-  "contentUrl": "https://video.wixstatic.com/video/a30e59_80d32f9209df49648fb7aba42c850ff2/1080p/mp4/file.mp4",
+  "contentUrl": "https://video.wixstatic.com/video/a30e59_cd34cc0952a04b7abc0c0682f6ab0d0a/720p/mp4/file.mp4",
   "uploadDate": "2026-06-14",
   "publisher": {
     "@type": "Organization",
@@ -177,7 +177,7 @@ html,body{width:100%;height:auto;overflow-x:hidden;overflow-y:visible;background
   // into MOBILE_SRC too. If you only have one video, leave MOBILE_SRC
   // equal to HERO_VIDEO_URL and it will be used everywhere.
   // ═══════════════════════════════════════════════════════════════
-  var HERO_VIDEO_URL = 'https://video.wixstatic.com/video/a30e59_80d32f9209df49648fb7aba42c850ff2/1080p/mp4/file.mp4';
+  var HERO_VIDEO_URL = 'https://video.wixstatic.com/video/a30e59_cd34cc0952a04b7abc0c0682f6ab0d0a/720p/mp4/file.mp4';
   var MOBILE_SRC     = HERO_VIDEO_URL;
   // ───────────────────────────────────────────────────────────────
 

--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -3,10 +3,39 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
+<!-- indexifembedded: allows Google to index this iframe's content as part of
+     the host page. Paired with the canonical below, which tells search engines
+     this content belongs to the /openwater page (not a standalone document). -->
 <meta name="robots" content="indexifembedded">
+<title>Open Water Guided Fishing — Detroit Lakes, Minnesota | Baxstar Fishing</title>
+<meta name="description" content="Detroit Lakes' only 100% private open water guided fishing. Walleye, bass, pike, and panfish from ice-out through fall with a 5× Master Angler — 4.9★ rated, 30+ years on the water.">
+<link rel="canonical" href="https://www.baxstarfishing.com/openwater">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- Preconnect to the Wix media/video hosts so the poster + hero video start
+     loading sooner (helps LCP). -->
+<link rel="preconnect" href="https://static.wixstatic.com" crossorigin>
+<link rel="preconnect" href="https://video.wixstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow+Condensed:wght@600;700;800&family=Barlow:wght@300;400&display=swap">
+
+<!-- VideoObject structured data — describes the hero background video to search
+     engines (name, thumbnail, file URL). Update uploadDate if you re-shoot it. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "Open Water Guided Fishing on Detroit Lakes — Baxstar Fishing",
+  "description": "Aerial footage of a private open water guided fishing trip on Detroit Lakes, Minnesota with Baxstar Fishing — walleye, bass, pike, and panfish from ice-out through fall.",
+  "thumbnailUrl": ["https://static.wixstatic.com/media/a30e59_f99144dec60b4cf4aa7bcc4f4762d2ff~mv2.webp"],
+  "contentUrl": "https://video.wixstatic.com/video/a30e59_5407852badf2476e9551855cb1323b0b/1080p/mp4/file.mp4",
+  "uploadDate": "2026-06-14",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Baxstar Fishing",
+    "url": "https://www.baxstarfishing.com"
+  }
+}
+</script>
 <style>
 *,*::before,*::after{box-sizing:border-box;margin:0;padding:0}
 html,body{width:100%;height:auto;overflow-x:hidden;overflow-y:visible;background:#08080a}

--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -5,11 +5,11 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <!-- indexifembedded: allows Google to index this iframe's content as part of
      the host page. Paired with the canonical below, which tells search engines
-     this content belongs to the /openwater page (not a standalone document). -->
+     this content belongs to the /fishing-trips page (not a standalone document). -->
 <meta name="robots" content="indexifembedded">
 <title>Open Water Guided Fishing — Detroit Lakes, Minnesota | Baxstar Fishing</title>
 <meta name="description" content="Detroit Lakes' only 100% private open water guided fishing. Walleye, bass, pike, and panfish from ice-out through fall with a 5× Master Angler — 4.9★ rated, 30+ years on the water.">
-<link rel="canonical" href="https://www.baxstarfishing.com/openwater">
+<link rel="canonical" href="https://www.baxstarfishing.com/fishing-trips">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <!-- Preconnect to the Wix media/video hosts so the poster + hero video start

--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -27,7 +27,7 @@
   "name": "Open Water Guided Fishing on Detroit Lakes — Baxstar Fishing",
   "description": "Aerial footage of a private open water guided fishing trip on Detroit Lakes, Minnesota with Baxstar Fishing — walleye, bass, pike, and panfish from ice-out through fall.",
   "thumbnailUrl": ["https://static.wixstatic.com/media/a30e59_f99144dec60b4cf4aa7bcc4f4762d2ff~mv2.webp"],
-  "contentUrl": "https://video.wixstatic.com/video/a30e59_5407852badf2476e9551855cb1323b0b/1080p/mp4/file.mp4",
+  "contentUrl": "https://video.wixstatic.com/video/a30e59_80d32f9209df49648fb7aba42c850ff2/1080p/mp4/file.mp4",
   "uploadDate": "2026-06-14",
   "publisher": {
     "@type": "Organization",
@@ -177,7 +177,7 @@ html,body{width:100%;height:auto;overflow-x:hidden;overflow-y:visible;background
   // into MOBILE_SRC too. If you only have one video, leave MOBILE_SRC
   // equal to HERO_VIDEO_URL and it will be used everywhere.
   // ═══════════════════════════════════════════════════════════════
-  var HERO_VIDEO_URL = 'https://video.wixstatic.com/video/a30e59_5407852badf2476e9551855cb1323b0b/1080p/mp4/file.mp4';
+  var HERO_VIDEO_URL = 'https://video.wixstatic.com/video/a30e59_80d32f9209df49648fb7aba42c850ff2/1080p/mp4/file.mp4';
   var MOBILE_SRC     = HERO_VIDEO_URL;
   // ───────────────────────────────────────────────────────────────
 

--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -97,6 +97,14 @@ html,body{width:100%;height:auto;overflow-x:hidden;overflow-y:visible;background
 @media (prefers-reduced-motion:reduce){
   *,*::before,*::after{animation-duration:0.01ms!important;transition-duration:0.01ms!important}
 }
+/* Desktop/tablet only: open up the lower hero so it fills the frame —
+   CTA sits ~80px lower and the stat strip ~100px lower than the tight
+   top-anchored layout, with the added space spread across the gaps. */
+@media(min-width:769px){
+  .hero__divider{margin:40px 0 44px}   /* +36px above the body */
+  .hero__body{margin-bottom:84px}      /* +44px → CTA 80px lower overall */
+  .hero__cta{margin-bottom:72px}       /* +20px → stat strip 100px lower overall */
+}
 @media(max-width:768px){
   .hero{min-height:auto;padding-bottom:24px}
   .hero__video video{object-position:50% 30%}

--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -100,7 +100,7 @@ html,body{width:100%;height:auto;overflow-x:hidden;overflow-y:visible;background
          loads (and if it fails). Replace the placeholder below or remove
          the poster attribute entirely. -->
     <video autoplay muted loop playsinline preload="auto" width="1920" height="1080"
-           poster="PASTE_POSTER_IMAGE_URL_HERE.jpg"></video>
+           poster="https://static.wixstatic.com/media/a30e59_f99144dec60b4cf4aa7bcc4f4762d2ff~mv2.webp"></video>
   </div>
   <div class="hero__veil" aria-hidden="true"></div>
   <div class="hero__vignette" aria-hidden="true"></div>

--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -61,7 +61,7 @@ html,body{width:100%;height:auto;overflow-x:hidden;overflow-y:visible;background
 .bracket--bl{bottom:24px;left:24px;border-bottom:1.5px solid var(--red);border-left:1.5px solid var(--red);animation-delay:0.54s}
 .bracket--br{bottom:24px;right:24px;border-bottom:1.5px solid var(--red);border-right:1.5px solid var(--red);animation-delay:0.66s}
 @keyframes bIn{to{opacity:1}}
-.hero__inner{position:relative;z-index:10;width:100%;max-width:680px;padding:clamp(80px,10vh,120px) clamp(32px,5vw,72px) clamp(60px,8vh,100px);display:flex;flex-direction:column;align-items:flex-start;justify-content:center}
+.hero__inner{position:relative;z-index:10;width:100%;max-width:680px;padding:clamp(72px,9vh,110px) clamp(32px,5vw,72px) clamp(60px,8vh,100px);display:flex;flex-direction:column;align-items:flex-start;justify-content:flex-start}
 .hero__eyebrow{display:inline-flex;align-items:center;gap:12px;font-family:'Barlow Condensed',sans-serif;font-size:10px;font-weight:600;letter-spacing:0.42em;text-transform:uppercase;color:var(--red);margin-bottom:20px;opacity:0;animation:fU 0.6s ease forwards;animation-delay:0.18s}
 .hero__eyebrow::before{content:'';display:block;width:22px;height:1px;background:var(--red)}
 .hero__headline{font-family:'Bebas Neue',sans-serif;font-size:clamp(58px,7.5vw,108px);line-height:0.9;letter-spacing:0.01em;color:var(--white);opacity:0;animation:fU 0.7s cubic-bezier(0.2,0,0,1) forwards;animation-delay:0.3s}

--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -148,7 +148,7 @@ html,body{width:100%;height:auto;overflow-x:hidden;overflow-y:visible;background
   // into MOBILE_SRC too. If you only have one video, leave MOBILE_SRC
   // equal to HERO_VIDEO_URL and it will be used everywhere.
   // ═══════════════════════════════════════════════════════════════
-  var HERO_VIDEO_URL = 'PASTE_YOUR_VIDEO_URL_HERE.mp4';
+  var HERO_VIDEO_URL = 'https://video.wixstatic.com/video/a30e59_5407852badf2476e9551855cb1323b0b/1080p/mp4/file.mp4';
   var MOBILE_SRC     = HERO_VIDEO_URL;
   // ───────────────────────────────────────────────────────────────
 

--- a/open_water_hero.html
+++ b/open_water_hero.html
@@ -101,7 +101,7 @@ html,body{width:100%;height:auto;overflow-x:hidden;overflow-y:visible;background
   .hero{min-height:auto;padding-bottom:24px}
   .hero__video video{object-position:50% 30%}
   .hero__veil{background:linear-gradient(180deg,rgba(8,8,10,0.55) 0%,rgba(8,8,10,0.35) 30%,rgba(8,8,10,0.7) 55%,rgba(8,8,10,0.95) 78%,rgba(8,8,10,0.98) 100%)}
-  .hero__inner{max-width:100%;padding:18svh 24px 36px;justify-content:flex-start;align-items:center;text-align:center;min-height:auto}
+  .hero__inner{max-width:100%;padding:calc(18svh - 100px) 24px 36px;justify-content:flex-start;align-items:center;text-align:center;min-height:auto}
   .hero__eyebrow{display:none}
   .hero__body{max-width:100%}
   .hero__cta{justify-content:center;gap:12px;margin-bottom:36px}

--- a/recent_guest_catches.html
+++ b/recent_guest_catches.html
@@ -4,12 +4,12 @@
 <meta charset="UTF-8">
 <!-- indexifembedded: allows Google to index this iframe's content as part of
      the host page. Paired with the canonical below, which tells search engines
-     this content belongs to the /openwater page (not a standalone document). -->
+     this content belongs to the /fishing-trips page (not a standalone document). -->
 <meta name="robots" content="indexifembedded"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Recent Guest Catches — Open Water Guided Fishing | Baxstar Fishing, Detroit Lakes MN</title>
 <meta name="description" content="Recent guest catches from private guided open water fishing trips with Baxstar Fishing — walleye, bass, pike, and panfish on Detroit Lakes, Minnesota.">
-<link rel="canonical" href="https://www.baxstarfishing.com/openwater">
+<link rel="canonical" href="https://www.baxstarfishing.com/fishing-trips">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <!-- Preconnect to the image host so the gallery photos start downloading sooner (LCP). -->
@@ -24,7 +24,7 @@
   "@type": "ImageGallery",
   "name": "Recent Guest Catches — Baxstar Fishing, Detroit Lakes, Minnesota",
   "description": "Recent catches from private guided open water fishing trips with Baxstar Fishing on Detroit Lakes, Minnesota — walleye, bass, pike, and panfish.",
-  "url": "https://www.baxstarfishing.com/openwater",
+  "url": "https://www.baxstarfishing.com/fishing-trips",
   "provider": {
     "@type": "LocalBusiness",
     "name": "Baxstar Fishing",

--- a/recent_guest_catches.html
+++ b/recent_guest_catches.html
@@ -2,12 +2,55 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<!-- indexifembedded: allows Google to index this iframe's content as part of
+     the host page. Paired with the canonical below, which tells search engines
+     this content belongs to the /openwater page (not a standalone document). -->
 <meta name="robots" content="indexifembedded"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Recent Guest Catches — Open Water Guided Fishing | Baxstar Fishing, Detroit Lakes MN</title>
 <meta name="description" content="Recent guest catches from private guided open water fishing trips with Baxstar Fishing — walleye, bass, pike, and panfish on Detroit Lakes, Minnesota.">
+<link rel="canonical" href="https://www.baxstarfishing.com/openwater">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<!-- Preconnect to the image host so the gallery photos start downloading sooner (LCP). -->
+<link rel="preconnect" href="https://static.wixstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow:wght@300;400;500;600;700&family=Barlow+Condensed:wght@500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&display=swap" rel="stylesheet">
+
+<!-- ImageGallery structured data — describes the 6 guest-catch photos to
+     search engines so they can surface in Google Images / rich results. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ImageGallery",
+  "name": "Recent Guest Catches — Baxstar Fishing, Detroit Lakes, Minnesota",
+  "description": "Recent catches from private guided open water fishing trips with Baxstar Fishing on Detroit Lakes, Minnesota — walleye, bass, pike, and panfish.",
+  "url": "https://www.baxstarfishing.com/openwater",
+  "provider": {
+    "@type": "LocalBusiness",
+    "name": "Baxstar Fishing",
+    "url": "https://www.baxstarfishing.com",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Detroit Lakes",
+      "addressRegion": "MN",
+      "addressCountry": "US"
+    }
+  },
+  "locationCreated": {
+    "@type": "Place",
+    "name": "Detroit Lakes, Minnesota",
+    "geo": { "@type": "GeoCoordinates", "latitude": 46.6519, "longitude": -95.8453 }
+  },
+  "image": [
+    { "@type": "ImageObject", "contentUrl": "https://static.wixstatic.com/media/a30e59_e375f06b2b5648f9a9eff691e772e330~mv2.webp", "caption": "Baxstar Fishing guest with a fresh catch on a private open water guided trip — Detroit Lakes, Minnesota" },
+    { "@type": "ImageObject", "contentUrl": "https://static.wixstatic.com/media/a30e59_968bf06d5a9644429cdd61254bac5fa8~mv2.webp", "caption": "Client showing off a fish caught on Detroit Lakes — Baxstar Fishing open water guided trip, Minnesota" },
+    { "@type": "ImageObject", "contentUrl": "https://static.wixstatic.com/media/a30e59_838af90d4cdc4586b89ffda7362a269d~mv2.webp", "caption": "Open water guided fishing success on Detroit Lakes — Baxstar Fishing guest catch, Minnesota" },
+    { "@type": "ImageObject", "contentUrl": "https://static.wixstatic.com/media/a30e59_67c2afbc00074d55909e09111d6549be~mv2.webp", "caption": "Guest holding a catch aboard the boat on a private Baxstar Fishing trip — Detroit Lakes, Minnesota" },
+    { "@type": "ImageObject", "contentUrl": "https://static.wixstatic.com/media/a30e59_f4b75d6f2dee43e8b47e6aeeaaca84eb~mv2.webp", "caption": "Happy guests with their catch from a guided open water trip — Baxstar Fishing, Detroit Lakes, Minnesota" },
+    { "@type": "ImageObject", "contentUrl": "https://static.wixstatic.com/media/a30e59_bb8b4f2f742d476b823a3108c656e684~mv2.webp", "caption": "Detroit Lakes open water guided fishing — recent guest catch with Baxstar Fishing, Minnesota" }
+  ]
+}
+</script>
 <style>
 *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -232,17 +275,15 @@ img { display: block; max-width: 100%; }
 <section class="gc-section" aria-labelledby="gc-h2">
 
   <div class="gc-header reveal">
-    <h3 class="section-tag">Straight From The Boat</h3>
+    <p class="section-tag">Straight From The Boat</p>
     <h2 class="gc-title" id="gc-h2">RECENT GUEST <span>CATCHES.</span><span class="sr-only"> — Walleye, Bass, Pike, and Panfish from private guided open water fishing trips on Detroit Lakes, Minnesota with Baxstar Fishing</span></h2>
     <p class="gc-sub">The latest fish our guests have put in the boat — real trips, real smiles, real Detroit Lakes water.</p>
   </div>
 
   <!-- ═══════════════════════════════════════════════════════════════
-       6 GUEST-CATCH PHOTOS — ▼ REPLACE EACH PLACEHOLDER URL ▼
-       In each card, paste your image URL into the src="" attribute
-       (replace PASTE_IMAGE_URL_#_HERE) and update the alt text to
-       describe the catch. Until you do, a numbered placeholder slot
-       shows in its place. Recommended: tall/portrait photos (4:5).
+       6 GUEST-CATCH PHOTOS — natural horizontal (3:2) cards, 2 per row.
+       To swap a photo later: replace the src URL and update both the
+       alt text and the <figcaption> to describe the new catch.
        ═══════════════════════════════════════════════════════════════ -->
   <div class="gc-grid">
 
@@ -252,8 +293,9 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">01</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="https://static.wixstatic.com/media/a30e59_e375f06b2b5648f9a9eff691e772e330~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_e375f06b2b5648f9a9eff691e772e330~mv2.webp" width="1200" height="800" decoding="async" loading="eager" alt="Baxstar Fishing guest with a fresh catch on a private open water guided trip — Detroit Lakes, Minnesota" onerror="this.style.display='none'">
       <span class="card-bar"></span>
+      <figcaption class="sr-only">Baxstar Fishing guest with a fresh catch on a private open water guided trip — Detroit Lakes, Minnesota.</figcaption>
     </figure>
 
     <!-- PHOTO 2 -->
@@ -262,8 +304,9 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">02</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="https://static.wixstatic.com/media/a30e59_968bf06d5a9644429cdd61254bac5fa8~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_968bf06d5a9644429cdd61254bac5fa8~mv2.webp" width="1200" height="800" decoding="async" loading="eager" alt="Client showing off a fish caught on Detroit Lakes — Baxstar Fishing open water guided trip, Minnesota" onerror="this.style.display='none'">
       <span class="card-bar"></span>
+      <figcaption class="sr-only">Client showing off a fish caught on Detroit Lakes — Baxstar Fishing open water guided trip, Minnesota.</figcaption>
     </figure>
 
     <!-- PHOTO 3 -->
@@ -272,8 +315,9 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">03</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="https://static.wixstatic.com/media/a30e59_838af90d4cdc4586b89ffda7362a269d~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_838af90d4cdc4586b89ffda7362a269d~mv2.webp" width="1200" height="800" decoding="async" loading="eager" alt="Open water guided fishing success on Detroit Lakes — Baxstar Fishing guest catch, Minnesota" onerror="this.style.display='none'">
       <span class="card-bar"></span>
+      <figcaption class="sr-only">Open water guided fishing success on Detroit Lakes — Baxstar Fishing guest catch, Minnesota.</figcaption>
     </figure>
 
     <!-- PHOTO 4 -->
@@ -282,8 +326,9 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">04</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="https://static.wixstatic.com/media/a30e59_67c2afbc00074d55909e09111d6549be~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_67c2afbc00074d55909e09111d6549be~mv2.webp" width="1200" height="800" decoding="async" loading="lazy" alt="Guest holding a catch aboard the boat on a private Baxstar Fishing trip — Detroit Lakes, Minnesota" onerror="this.style.display='none'">
       <span class="card-bar"></span>
+      <figcaption class="sr-only">Guest holding a catch aboard the boat on a private Baxstar Fishing trip — Detroit Lakes, Minnesota.</figcaption>
     </figure>
 
     <!-- PHOTO 5 -->
@@ -292,8 +337,9 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">05</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="https://static.wixstatic.com/media/a30e59_f4b75d6f2dee43e8b47e6aeeaaca84eb~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_f4b75d6f2dee43e8b47e6aeeaaca84eb~mv2.webp" width="1200" height="800" decoding="async" loading="lazy" alt="Happy guests with their catch from a guided open water trip — Baxstar Fishing, Detroit Lakes, Minnesota" onerror="this.style.display='none'">
       <span class="card-bar"></span>
+      <figcaption class="sr-only">Happy guests with their catch from a guided open water trip — Baxstar Fishing, Detroit Lakes, Minnesota.</figcaption>
     </figure>
 
     <!-- PHOTO 6 -->
@@ -302,8 +348,9 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">06</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="https://static.wixstatic.com/media/a30e59_bb8b4f2f742d476b823a3108c656e684~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_bb8b4f2f742d476b823a3108c656e684~mv2.webp" width="1200" height="800" decoding="async" loading="lazy" alt="Detroit Lakes open water guided fishing — recent guest catch with Baxstar Fishing, Minnesota" onerror="this.style.display='none'">
       <span class="card-bar"></span>
+      <figcaption class="sr-only">Detroit Lakes open water guided fishing — recent guest catch with Baxstar Fishing, Minnesota.</figcaption>
     </figure>
 
   </div>

--- a/recent_guest_catches.html
+++ b/recent_guest_catches.html
@@ -253,7 +253,7 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">01</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="PASTE_IMAGE_URL_1_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_e375f06b2b5648f9a9eff691e772e330~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
       <span class="card-bar"></span>
     </figure>
 
@@ -263,7 +263,7 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">02</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="PASTE_IMAGE_URL_2_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_968bf06d5a9644429cdd61254bac5fa8~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
       <span class="card-bar"></span>
     </figure>
 
@@ -273,7 +273,7 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">03</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="PASTE_IMAGE_URL_3_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_838af90d4cdc4586b89ffda7362a269d~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
       <span class="card-bar"></span>
     </figure>
 
@@ -283,7 +283,7 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">04</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="PASTE_IMAGE_URL_4_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_67c2afbc00074d55909e09111d6549be~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
       <span class="card-bar"></span>
     </figure>
 
@@ -293,7 +293,7 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">05</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="PASTE_IMAGE_URL_5_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_f4b75d6f2dee43e8b47e6aeeaaca84eb~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
       <span class="card-bar"></span>
     </figure>
 
@@ -303,7 +303,7 @@ img { display: block; max-width: 100%; }
         <span class="gc-slot-num">06</span>
         <span class="gc-slot-lbl">Replace Image</span>
       </div>
-      <img src="PASTE_IMAGE_URL_6_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
+      <img src="https://static.wixstatic.com/media/a30e59_bb8b4f2f742d476b823a3108c656e684~mv2.webp" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
       <span class="card-bar"></span>
     </figure>
 

--- a/recent_guest_catches.html
+++ b/recent_guest_catches.html
@@ -276,7 +276,7 @@ img { display: block; max-width: 100%; }
 
   <div class="gc-header reveal">
     <p class="section-tag">Straight From The Boat</p>
-    <h2 class="gc-title" id="gc-h2">RECENT GUEST <span>CATCHES.</span><span class="sr-only"> — Walleye, Bass, Pike, and Panfish from private guided open water fishing trips across Minnesota's lakes with Baxstar Fishing</span></h2>
+    <h2 class="gc-title" id="gc-h2">RECENT GUEST <span>CATCHES.</span><span class="sr-only"> — Walleye, Bass, Pike, and Panfish from private guided open water fishing trips on the many lakes in the Detroit Lakes, Minnesota area with Baxstar Fishing</span></h2>
     <p class="gc-sub">The latest fish our guests have put in the boat — real trips, real smiles, from the many lakes we fish.</p>
   </div>
 

--- a/recent_guest_catches.html
+++ b/recent_guest_catches.html
@@ -26,7 +26,8 @@
   --font-accent:    'Cormorant Garamond', serif;
   --red-glow: rgba(193,39,45,0.55);
   --ease: cubic-bezier(0.4, 0, 0.2, 1);
-  --photo-ratio: 4 / 5;
+  /* Natural horizontal (landscape) catch photos */
+  --photo-ratio: 3 / 2;
 }
 
 html { scroll-behavior: smooth; }
@@ -97,12 +98,12 @@ img { display: block; max-width: 100%; }
   margin: 0 auto;
 }
 
-/* ── 6-photo grid: 3 columns desktop · 2 columns tablet · 1 column phone ── */
+/* ── 6-photo grid: 2 columns on desktop/tablet · 1 column on phone ── */
 .gc-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: clamp(10px, 1.4vw, 18px);
-  max-width: 1180px;
+  grid-template-columns: repeat(2, 1fr);
+  gap: clamp(12px, 1.6vw, 22px);
+  max-width: 1060px;
   margin: 0 auto;
   padding: 0 clamp(16px, 4vw, 56px);
 }
@@ -220,11 +221,9 @@ img { display: block; max-width: 100%; }
   .reveal { opacity: 1; transform: none; transition: none; will-change: auto; }
 }
 
-@media (max-width: 880px) {
-  .gc-grid { grid-template-columns: repeat(2, 1fr); }
-}
-@media (max-width: 520px) {
-  .gc-grid { grid-template-columns: 1fr; max-width: 420px; }
+/* Phones only: stack to a single column */
+@media (max-width: 600px) {
+  .gc-grid { grid-template-columns: 1fr; max-width: 520px; }
 }
 </style>
 </head>

--- a/recent_guest_catches.html
+++ b/recent_guest_catches.html
@@ -276,8 +276,8 @@ img { display: block; max-width: 100%; }
 
   <div class="gc-header reveal">
     <p class="section-tag">Straight From The Boat</p>
-    <h2 class="gc-title" id="gc-h2">RECENT GUEST <span>CATCHES.</span><span class="sr-only"> — Walleye, Bass, Pike, and Panfish from private guided open water fishing trips on Detroit Lakes, Minnesota with Baxstar Fishing</span></h2>
-    <p class="gc-sub">The latest fish our guests have put in the boat — real trips, real smiles, real Detroit Lakes water.</p>
+    <h2 class="gc-title" id="gc-h2">RECENT GUEST <span>CATCHES.</span><span class="sr-only"> — Walleye, Bass, Pike, and Panfish from private guided open water fishing trips across Minnesota's lakes with Baxstar Fishing</span></h2>
+    <p class="gc-sub">The latest fish our guests have put in the boat — real trips, real smiles, from the many lakes we fish.</p>
   </div>
 
   <!-- ═══════════════════════════════════════════════════════════════

--- a/recent_guest_catches.html
+++ b/recent_guest_catches.html
@@ -90,7 +90,10 @@ img { display: block; max-width: 100%; }
 .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
 
 .gc-section {
-  padding: clamp(56px, 6.3vw, 91px) 0 clamp(56px, 6vw, 84px);
+  /* Bottom space below the CTA reduced by 100px from the original
+     clamp(56px,6vw,84px); since that maxed at ~84px, the trailing gap
+     bottoms out at 0. */
+  padding: clamp(56px, 6.3vw, 91px) 0 0;
   background: var(--black);
   position: relative;
 }
@@ -220,7 +223,8 @@ img { display: block; max-width: 100%; }
 .gc-cta {
   display: flex;
   justify-content: center;
-  margin-top: clamp(34px, 4vw, 52px);
+  /* Button nudged down 30px from its original top margin */
+  margin-top: calc(clamp(34px, 4vw, 52px) + 30px);
   padding: 0 clamp(14px, 3.5vw, 56px);
 }
 .btn-primary {

--- a/recent_guest_catches.html
+++ b/recent_guest_catches.html
@@ -1,0 +1,386 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="robots" content="indexifembedded"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Recent guest catches from private guided open water fishing trips with Baxstar Fishing — walleye, bass, pike, and panfish on Detroit Lakes, Minnesota.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Barlow:wght@300;400;500;600;700&family=Barlow+Condensed:wght@500;600;700&family=Cormorant+Garamond:ital,wght@0,400;0,500;1,400;1,500&display=swap" rel="stylesheet">
+<style>
+*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+
+:root {
+  --black:       #08080a;
+  --red:         #c1272d;
+  --red-bright:  #e63946;
+  --cream:       #f0ece4;
+  --warm-white:  #faf8f4;
+  --light-slate: #9a9aaa;
+  --bone:        #c8c5bd;
+  --pearl:       #e8e6e0;
+  --font-display:   'Bebas Neue', sans-serif;
+  --font-body:      'Barlow', sans-serif;
+  --font-condensed: 'Barlow Condensed', sans-serif;
+  --font-accent:    'Cormorant Garamond', serif;
+  --red-glow: rgba(193,39,45,0.55);
+  --ease: cubic-bezier(0.4, 0, 0.2, 1);
+  --photo-ratio: 4 / 5;
+}
+
+html { scroll-behavior: smooth; }
+/* Baxstar iframe scroll standard — bg on BOTH html and body so any
+   sub-pixel seam between Wix container and iframe blends invisibly. */
+html, body {
+  width: 100%; height: auto;
+  overflow-x: hidden; overflow-y: visible;
+  background: var(--black);
+}
+body {
+  font-family: var(--font-body);
+  color: var(--cream);
+  -webkit-font-smoothing: antialiased;
+}
+img { display: block; max-width: 100%; }
+.sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
+
+.gc-section {
+  padding: clamp(56px, 6.3vw, 91px) 0 clamp(56px, 6vw, 84px);
+  background: var(--black);
+  position: relative;
+}
+.gc-section::before {
+  content: '';
+  position: absolute; inset: 0;
+  background: radial-gradient(ellipse 70% 40% at 50% 0%, rgba(193,39,45,0.05) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.gc-header {
+  text-align: center;
+  padding: 0 clamp(14px, 3.5vw, 56px);
+  margin-bottom: clamp(34px, 4vw, 52px);
+}
+.section-tag {
+  font-family: var(--font-condensed);
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: var(--red-bright);
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+}
+.section-tag::before, .section-tag::after {
+  content: ''; width: 28px; height: 1px; background: var(--red);
+}
+.gc-title {
+  font-family: var(--font-display);
+  font-size: clamp(36px, 5vw, 58px);
+  line-height: 1; letter-spacing: 0.012em;
+  text-transform: uppercase;
+  color: var(--warm-white);
+  margin-bottom: 14px;
+}
+.gc-title span { color: var(--red-bright); }
+.gc-sub {
+  font-family: var(--font-accent);
+  font-style: italic;
+  font-size: clamp(17px, 1.7vw, 20px);
+  color: var(--bone);
+  line-height: 1.55;
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* ── 6-photo grid: 3 columns desktop · 2 columns tablet · 1 column phone ── */
+.gc-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: clamp(10px, 1.4vw, 18px);
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 clamp(16px, 4vw, 56px);
+}
+.gc-card {
+  position: relative;
+  aspect-ratio: var(--photo-ratio);
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.05);
+  background: #111114;
+  cursor: pointer;
+  transition: border-color 0.3s ease;
+}
+.gc-card:hover { border-color: rgba(193,39,45,0.4); }
+
+/* Placeholder slot — visible until a real image URL is pasted in.
+   The <img> stacks on top; once it loads it fully covers this label. */
+.gc-slot {
+  position: absolute; inset: 0; z-index: 0;
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  gap: 8px;
+  background:
+    repeating-linear-gradient(45deg, rgba(255,255,255,0.018) 0 12px, transparent 12px 24px),
+    #121216;
+  color: var(--light-slate);
+  text-align: center;
+  padding: 16px;
+}
+.gc-slot .gc-slot-num {
+  font-family: var(--font-display);
+  font-size: clamp(34px, 4vw, 46px);
+  line-height: 1;
+  color: rgba(240,236,228,0.18);
+}
+.gc-slot .gc-slot-lbl {
+  font-family: var(--font-condensed);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.26em;
+  text-transform: uppercase;
+  color: rgba(154,154,170,0.7);
+}
+
+.gc-card img {
+  position: relative; z-index: 1;
+  width: 100%; height: 100%;
+  object-fit: cover;
+  object-position: center center;
+  transition: transform 0.6s ease, filter 0.4s ease;
+  filter: brightness(0.92) saturate(1.05);
+}
+.gc-card:hover img {
+  transform: scale(1.04);
+  filter: brightness(1) saturate(1.12);
+}
+.gc-card::after {
+  content: '';
+  position: absolute; inset: 0; z-index: 2;
+  background: linear-gradient(to bottom, transparent 60%, rgba(8,8,10,0.5) 100%);
+  pointer-events: none;
+}
+.card-bar {
+  position: absolute; bottom: 0; left: 0; right: 0; z-index: 3;
+  height: 3px; background: var(--red);
+  transform: scaleX(0); transform-origin: left;
+  transition: transform 0.4s ease;
+}
+.gc-card:hover .card-bar { transform: scaleX(1); }
+
+/* CTA below grid — site-canonical slant button (matches CTA / pricing / gallery) */
+.gc-cta {
+  display: flex;
+  justify-content: center;
+  margin-top: clamp(34px, 4vw, 52px);
+  padding: 0 clamp(14px, 3.5vw, 56px);
+}
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 16px 36px;
+  background: var(--red); color: #fff;
+  font-family: var(--font-body); font-weight: 600; font-size: 13px;
+  letter-spacing: 0.18em; text-transform: uppercase;
+  border: none; cursor: pointer; text-decoration: none;
+  transition: all 0.3s var(--ease); position: relative; overflow: hidden;
+  transform: skewX(-12deg); white-space: nowrap;
+}
+.btn-primary > * { display: inline-flex; align-items: center; transform: skewX(12deg); }
+.btn-primary svg {
+  width: 14px; height: 14px;
+  fill: none; stroke: currentColor; stroke-width: 2.2;
+  flex-shrink: 0;
+  transition: transform 0.3s var(--ease);
+}
+.btn-primary::after {
+  content: ''; position: absolute; inset: 0;
+  background: linear-gradient(120deg, rgba(255,255,255,0.18), transparent 60%);
+  opacity: 0; transition: opacity 0.32s var(--ease);
+  pointer-events: none;
+}
+.btn-primary:hover {
+  background: var(--red-bright);
+  transform: skewX(-12deg) translateY(-2px);
+  box-shadow: 0 10px 30px var(--red-glow);
+}
+.btn-primary:hover::after { opacity: 1; }
+.btn-primary:hover svg { transform: skewX(12deg) translateX(4px); }
+
+.reveal {
+  opacity: 0; transform: translateY(22px);
+  transition: opacity 0.75s ease, transform 0.75s ease;
+  will-change: transform, opacity;
+}
+.reveal.visible { opacity: 1; transform: translateY(0); will-change: auto; }
+@media (prefers-reduced-motion: reduce) {
+  .reveal { opacity: 1; transform: none; transition: none; will-change: auto; }
+}
+
+@media (max-width: 880px) {
+  .gc-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 520px) {
+  .gc-grid { grid-template-columns: 1fr; max-width: 420px; }
+}
+</style>
+</head>
+<body>
+
+<section class="gc-section" aria-labelledby="gc-h2">
+
+  <div class="gc-header reveal">
+    <h3 class="section-tag">Straight From The Boat</h3>
+    <h2 class="gc-title" id="gc-h2">RECENT GUEST <span>CATCHES.</span><span class="sr-only"> — Walleye, Bass, Pike, and Panfish from private guided open water fishing trips on Detroit Lakes, Minnesota with Baxstar Fishing</span></h2>
+    <p class="gc-sub">The latest fish our guests have put in the boat — real trips, real smiles, real Detroit Lakes water.</p>
+  </div>
+
+  <!-- ═══════════════════════════════════════════════════════════════
+       6 GUEST-CATCH PHOTOS — ▼ REPLACE EACH PLACEHOLDER URL ▼
+       In each card, paste your image URL into the src="" attribute
+       (replace PASTE_IMAGE_URL_#_HERE) and update the alt text to
+       describe the catch. Until you do, a numbered placeholder slot
+       shows in its place. Recommended: tall/portrait photos (4:5).
+       ═══════════════════════════════════════════════════════════════ -->
+  <div class="gc-grid">
+
+    <!-- PHOTO 1 -->
+    <figure class="gc-card reveal">
+      <div class="gc-slot" aria-hidden="true">
+        <span class="gc-slot-num">01</span>
+        <span class="gc-slot-lbl">Replace Image</span>
+      </div>
+      <img src="PASTE_IMAGE_URL_1_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
+      <span class="card-bar"></span>
+    </figure>
+
+    <!-- PHOTO 2 -->
+    <figure class="gc-card reveal">
+      <div class="gc-slot" aria-hidden="true">
+        <span class="gc-slot-num">02</span>
+        <span class="gc-slot-lbl">Replace Image</span>
+      </div>
+      <img src="PASTE_IMAGE_URL_2_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
+      <span class="card-bar"></span>
+    </figure>
+
+    <!-- PHOTO 3 -->
+    <figure class="gc-card reveal">
+      <div class="gc-slot" aria-hidden="true">
+        <span class="gc-slot-num">03</span>
+        <span class="gc-slot-lbl">Replace Image</span>
+      </div>
+      <img src="PASTE_IMAGE_URL_3_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="eager" onerror="this.style.display='none'">
+      <span class="card-bar"></span>
+    </figure>
+
+    <!-- PHOTO 4 -->
+    <figure class="gc-card reveal">
+      <div class="gc-slot" aria-hidden="true">
+        <span class="gc-slot-num">04</span>
+        <span class="gc-slot-lbl">Replace Image</span>
+      </div>
+      <img src="PASTE_IMAGE_URL_4_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
+      <span class="card-bar"></span>
+    </figure>
+
+    <!-- PHOTO 5 -->
+    <figure class="gc-card reveal">
+      <div class="gc-slot" aria-hidden="true">
+        <span class="gc-slot-num">05</span>
+        <span class="gc-slot-lbl">Replace Image</span>
+      </div>
+      <img src="PASTE_IMAGE_URL_5_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
+      <span class="card-bar"></span>
+    </figure>
+
+    <!-- PHOTO 6 -->
+    <figure class="gc-card reveal">
+      <div class="gc-slot" aria-hidden="true">
+        <span class="gc-slot-num">06</span>
+        <span class="gc-slot-lbl">Replace Image</span>
+      </div>
+      <img src="PASTE_IMAGE_URL_6_HERE" alt="Recent guest catch — Baxstar Fishing, Detroit Lakes Minnesota" loading="lazy" onerror="this.style.display='none'">
+      <span class="card-bar"></span>
+    </figure>
+
+  </div>
+
+  <div class="gc-cta reveal">
+    <a href="https://www.baxstarfishing.com/fishgallery" class="btn-primary" target="_top" aria-label="View the full fish gallery">
+      <span>View Full Gallery</span>
+      <span><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg></span>
+    </a>
+  </div>
+
+</section>
+
+<script>
+// Scroll reveal
+(function() {
+  var revs = document.querySelectorAll('.reveal');
+  if (!revs.length) return;
+  revs.forEach(function(el, i) { el.style.transitionDelay = (i * 65) + 'ms'; });
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    revs.forEach(function(el) { el.style.transitionDelay = '0ms'; el.classList.add('visible'); });
+    return;
+  }
+  var io = new IntersectionObserver(function(entries) {
+    entries.forEach(function(entry) {
+      if (entry.isIntersecting) {
+        requestAnimationFrame(function() { entry.target.classList.add('visible'); });
+        io.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.08, rootMargin: '0px 0px -30px 0px' });
+  revs.forEach(function(el) { io.observe(el); });
+}());
+</script>
+
+<!-- IFRAME HEIGHT REPORTER — multi-signal (Wix Custom Embed auto-resize) -->
+<script>
+(function(){
+  if (window.parent === window) return;
+  var lastH = 0;
+  function report(){
+    var h = Math.ceil(Math.max(
+      document.documentElement.scrollHeight,
+      document.body ? document.body.scrollHeight : 0,
+      document.documentElement.offsetHeight,
+      document.body ? document.body.offsetHeight : 0,
+      document.documentElement.getBoundingClientRect().height
+    ));
+    if (h && Math.abs(h - lastH) >= 1) {
+      lastH = h;
+      try { window.parent.postMessage({ type: 'setHeight', height: h }, '*'); } catch(e){}
+      try { window.parent.postMessage({ type: 'embed-size', height: h }, '*'); } catch(e){}
+      try { window.parent.postMessage('height:' + h, '*'); } catch(e){}
+    }
+  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', report);
+  else report();
+  window.addEventListener('load', report);
+  window.addEventListener('resize', report);
+  if (document.fonts && document.fonts.ready) document.fonts.ready.then(report);
+  if (window.ResizeObserver) {
+    try { var ro = new ResizeObserver(report); ro.observe(document.documentElement); if (document.body) ro.observe(document.body); } catch(e){}
+  }
+  if (window.MutationObserver && document.body) {
+    try { new MutationObserver(report).observe(document.body, { subtree:true, childList:true, attributes:true, attributeFilter:['class','style'] }); } catch(e){}
+  }
+  document.addEventListener('transitionend', function(e){
+    if (e.target && e.target.classList && e.target.classList.contains('reveal')) report();
+  }, true);
+  var ticks = 0;
+  var early = setInterval(function(){
+    report(); ticks++;
+    if (ticks >= 30) { clearInterval(early); setInterval(report, 1500); }
+  }, 200);
+})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## What this adds

Two new embeddable sections for the **/openwater** page, both built in the established Baxstar design language (Bebas Neue / Barlow / Barlow Condensed / Cormorant, `#08080a` ground, `#c1272d` red accent) and Wix-iframe ready (multi-signal height reporter, scroll standard).

### `open_water_hero.html` — replaces the first section
- Full-bleed **video-background hero**, styled to match `baxstar_hero_video_banner.html` (corner brackets, eyebrow, ghost/accent headline, divider, body copy, dual CTAs, credential stat strip).
- **Video placeholder:** paste your URL into `HERE_VIDEO_URL` → `PASTE_YOUR_VIDEO_URL_HERE.mp4`. Optional `MOBILE_SRC` for a lighter phone file, and an optional `poster` image placeholder on the `<video>` tag.
- Until a real URL is pasted, it shows the poster (no broken-video flash) instead of trying to load the placeholder.
- Keeps the homepage's bandwidth-aware loading, one-shot fallback, offscreen-pause, and FareHarbor booking postMessage bridge.

### `recent_guest_catches.html` — middle section
- Heading **"Recent Guest Catches"** with section tag + italic sub.
- Responsive **6-photo grid** (3 cols desktop · 2 tablet · 1 phone) with the canonical photo-card treatment (hover zoom, red underline bar).
- **6 image placeholders:** each card has a numbered "Replace Image" slot; paste a URL into the `src` and the photo covers the slot automatically (`onerror` hides broken placeholders).
- Slant "View Full Gallery" CTA matching the rest of the site.

## Notes
- The live `baxstarfishing.com/openwater` page is behind Wix bot protection (403 on fetch), so the **Recent Guest Catches** section was rebuilt as a 6-photo grid in the repo's section style rather than scraped 1:1. If the live layout differs (e.g. captions, different column count), let me know and I'll match it.
- Both are standalone embed HTML files — drop each into a Wix Custom Embed (HTML iframe) element on the Open Water page.

https://claude.ai/code/session_01HehhRSoVh6SNJ9mVNj88eQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HehhRSoVh6SNJ9mVNj88eQ)_