### PR TITLE
FAQ: fatten six answers to the 40-60 word standard, schema kept in sync

### DIFF
--- a/baxstar_faq.html
+++ b/baxstar_faq.html
@@ -108,7 +108,7 @@
       "name": "What fish species can we target?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Baxstar trips commonly target walleye, bass, northern pike, and panfish depending on the season, weather, and group goals. Brady chooses the best species and lake based on current conditions, not a fixed script."
+        "text": "Baxstar trips commonly target walleye, smallmouth and largemouth bass, northern pike, crappie, and bluegill depending on the season, weather, and group goals. Brady reads current conditions across the Detroit Lakes area and picks the species and water that give your group the best day — not a fixed script."
       }
     },
     {
@@ -116,7 +116,7 @@
       "name": "Is the boat private, or do I share it with other clients?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Your group has the boat and the guide for the full trip."
+        "text": "Yes — every Baxstar trip is 100% private, so you never share the boat with strangers. Your group has the Vexus DVX20S and Brady's full attention from launch to landing, at your pace, with coaching matched to your crew's experience level."
       }
     },
     {
@@ -132,7 +132,7 @@
       "name": "What should I bring on a guided fishing trip?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Bring a valid Minnesota fishing license, weather-appropriate clothing, sunglasses, sunscreen, snacks, drinks, and a cooler for fish if you plan to keep any. Baxstar provides the boat, fuel, rods, reels, tackle, bait, life jackets, sonar, and instruction."
+        "text": "Bring a valid Minnesota fishing license, weather-appropriate clothing, sunglasses, sunscreen, snacks, drinks, and a cooler for fish if you plan to keep any. Baxstar provides everything else — the boat, fuel, quality rods and reels, tackle, bait, life jackets, Garmin LiveScope sonar, and hands-on instruction from the first cast."
       }
     },
     {
@@ -148,7 +148,7 @@
       "name": "Can we keep the fish we catch?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes, when fish are legal to keep and within Minnesota regulations. Brady helps guests understand current limits, slot restrictions, and what makes sense to harvest. Catch cleaning is available when requested."
+        "text": "Yes, when fish are legal to keep and within Minnesota regulations. Brady helps guests understand current limits, slot restrictions, and which fish make sense to harvest versus release for the fishery's future. Catch cleaning is available when requested, so dinner can come home ready for the pan."
       }
     },
     {
@@ -156,7 +156,7 @@
       "name": "What boat and equipment does Baxstar Fishing use?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Brady runs a Vexus DVX20S, a tournament-grade fiberglass walleye boat with Garmin LiveScope live-imaging sonar, dual livewells, comfortable seating, and a premium rod-and-reel setup. The boat is designed to handle changing conditions and give clients room to fish comfortably."
+        "text": "Brady runs a Vexus DVX20S, a tournament-grade fiberglass walleye boat rigged with a Mercury Pro XS 300, Minn Kota Ultrex trolling motor, twin Power-Poles, and dual Garmin LiveScope live-imaging sonar. The deep-V hull handles changing big-water conditions, and the open layout gives clients room to fish comfortably."
       }
     },
     {
@@ -188,7 +188,7 @@
       "name": "Does Baxstar offer ice fishing trips or winter rentals?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Yes. Baxstar offers seasonal open-water guided fishing and winter ice fishing experiences in the Detroit Lakes area. Winter options may include guided ice fishing, Ice Castle rentals, and other cold-weather fishing experiences depending on availability and conditions."
+        "text": "Yes — Baxstar runs open-water guided trips all season and winter ice fishing experiences in the Detroit Lakes area. Winter options may include guided ice fishing, Ice Castle rentals, and other cold-weather experiences depending on availability, ice conditions, and the year's schedule. Ask about winter dates when you book."
       }
     }
   ]
@@ -2179,7 +2179,7 @@ button { font:inherit; background:none; border:none; color:inherit; cursor:point
           <div class="faq__panel" id="faq-panel-06" role="region" aria-labelledby="faq-trigger-06">
             <div class="faq__panel-inner">
               <p class="faq__answer" itemscope itemtype="https://schema.org/Answer" itemprop="acceptedAnswer">
-                <span itemprop="text"><strong>Baxstar trips commonly target walleye, bass, northern pike, and panfish</strong> depending on the season, weather, and group goals. Brady chooses the best species and lake based on current conditions, not a fixed script.</span>
+                <span itemprop="text"><strong>Baxstar trips commonly target walleye, smallmouth and largemouth bass, northern pike, crappie, and bluegill</strong> depending on the season, weather, and group goals. Brady reads current conditions across the Detroit Lakes area and picks the species and water that give your group the best day — not a fixed script.</span>
               </p>
             </div>
           </div>
@@ -2198,7 +2198,7 @@ button { font:inherit; background:none; border:none; color:inherit; cursor:point
           <div class="faq__panel" id="faq-panel-07" role="region" aria-labelledby="faq-trigger-07">
             <div class="faq__panel-inner">
               <p class="faq__answer" itemscope itemtype="https://schema.org/Answer" itemprop="acceptedAnswer">
-                <span itemprop="text"><strong>Yes.</strong> Your group has the boat and the guide for the full trip.</span>
+                <span itemprop="text"><strong>Yes — every Baxstar trip is 100% private, so you never share the boat with strangers.</strong> Your group has the Vexus DVX20S and Brady's full attention from launch to landing, at your pace, with coaching matched to your crew's experience level.</span>
               </p>
             </div>
           </div>
@@ -2236,7 +2236,7 @@ button { font:inherit; background:none; border:none; color:inherit; cursor:point
           <div class="faq__panel" id="faq-panel-09" role="region" aria-labelledby="faq-trigger-09">
             <div class="faq__panel-inner">
               <p class="faq__answer" itemscope itemtype="https://schema.org/Answer" itemprop="acceptedAnswer">
-                <span itemprop="text"><strong>Bring a valid Minnesota fishing license, weather-appropriate clothing, sunglasses, sunscreen, snacks, drinks, and a cooler for fish if you plan to keep any.</strong> Baxstar provides the boat, fuel, rods, reels, tackle, bait, life jackets, sonar, and instruction.</span>
+                <span itemprop="text"><strong>Bring a valid Minnesota fishing license, weather-appropriate clothing, sunglasses, sunscreen, snacks, drinks, and a cooler for fish if you plan to keep any.</strong> Baxstar provides everything else — the boat, fuel, quality rods and reels, tackle, bait, life jackets, Garmin LiveScope sonar, and hands-on instruction from the first cast.</span>
               </p>
             </div>
           </div>
@@ -2274,7 +2274,7 @@ button { font:inherit; background:none; border:none; color:inherit; cursor:point
           <div class="faq__panel" id="faq-panel-11" role="region" aria-labelledby="faq-trigger-11">
             <div class="faq__panel-inner">
               <p class="faq__answer" itemscope itemtype="https://schema.org/Answer" itemprop="acceptedAnswer">
-                <span itemprop="text"><strong>Yes, when fish are legal to keep and within Minnesota regulations.</strong> Brady helps guests understand current limits, slot restrictions, and what makes sense to harvest. Catch cleaning is available when requested.</span>
+                <span itemprop="text"><strong>Yes, when fish are legal to keep and within Minnesota regulations.</strong> Brady helps guests understand current limits, slot restrictions, and which fish make sense to harvest versus release for the fishery's future. Catch cleaning is available when requested, so dinner can come home ready for the pan.</span>
               </p>
             </div>
           </div>
@@ -2293,7 +2293,7 @@ button { font:inherit; background:none; border:none; color:inherit; cursor:point
           <div class="faq__panel" id="faq-panel-12" role="region" aria-labelledby="faq-trigger-12">
             <div class="faq__panel-inner">
               <p class="faq__answer" itemscope itemtype="https://schema.org/Answer" itemprop="acceptedAnswer">
-                <span itemprop="text"><strong>Brady runs a Vexus DVX20S, a tournament-grade fiberglass walleye boat with Garmin LiveScope live-imaging sonar, dual livewells, comfortable seating, and a premium rod-and-reel setup.</strong> The boat is designed to handle changing conditions and give clients room to fish comfortably.</span>
+                <span itemprop="text"><strong>Brady runs a Vexus DVX20S, a tournament-grade fiberglass walleye boat rigged with a Mercury Pro XS 300, Minn Kota Ultrex trolling motor, twin Power-Poles, and dual Garmin LiveScope live-imaging sonar.</strong> The deep-V hull handles changing big-water conditions, and the open layout gives clients room to fish comfortably.</span>
               </p>
             </div>
           </div>
@@ -2369,7 +2369,7 @@ button { font:inherit; background:none; border:none; color:inherit; cursor:point
           <div class="faq__panel" id="faq-panel-16" role="region" aria-labelledby="faq-trigger-16">
             <div class="faq__panel-inner">
               <p class="faq__answer" itemscope itemtype="https://schema.org/Answer" itemprop="acceptedAnswer">
-                <span itemprop="text"><strong>Yes.</strong> Baxstar offers seasonal open-water guided fishing and winter ice fishing experiences in the Detroit Lakes area. Winter options may include guided ice fishing, Ice Castle rentals, and other cold-weather fishing experiences depending on availability and conditions.</span>
+                <span itemprop="text"><strong>Yes — Baxstar runs open-water guided trips all season and winter ice fishing experiences in the Detroit Lakes area.</strong> Winter options may include guided ice fishing, Ice Castle rentals, and other cold-weather experiences depending on availability, ice conditions, and the year's schedule. Ask about winter dates when you book.</span>
               </p>
             </div>
           </div>


### PR DESCRIPTION
Per Brady: fatten the short FAQ answers before pasting the FAQPage structured data into the Wix `/faq` page, so the schema and the visible page text stay identical.

**What changed** (visible answer + matching JSON-LD entry for each, 12 edits total):
- **Q6 species** (33→48w): names smallmouth/largemouth, crappie, bluegill; Detroit Lakes area conditions framing.
- **Q7 private boat** (13→41w): "100% private, never share the boat with strangers" + Vexus DVX20S, launch-to-landing coaching.
- **Q9 what to bring** (37→49w): Garmin LiveScope sonar, quality rods/reels, "hands-on instruction from the first cast."
- **Q11 keeping fish** (31→47w): harvest-vs-release stewardship framing + catch cleaning "ready for the pan."
- **Q12 boat & equipment** (39→47w): full rig list — Mercury Pro XS 300, Minn Kota Ultrex, twin Power-Poles, dual Garmin LiveScope — matching the boat page specs.
- **Q16 winter** (37→48w): tightened BLUF, Ice Castle rentals kept, neutral "ask about winter dates when you book."

**Verified:** all 16 schema questions and answers match visible text word-for-word; every answer now 41–57 words (was 13–57); BLUF-bold first sentences preserved; prohibited-phrase scan clean (no "one group per day", no Scheels, no 5-guest norm, no manufactured urgency).

Note for deploy: the Wix `/faq` embed shows a copy of this file — after merging, refresh the embed content and paste the regenerated FAQPage JSON-LD into the Wix page's SEO structured-data settings so the indexed page and schema stay aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZYLDhWo2cpenrRTQqd7ds

---
_Generated by [Claude Code](https://claude.ai/code/session_011ZYLDhWo2cpenrRTQqd7ds)_